### PR TITLE
Develop

### DIFF
--- a/source/partials/_card.html.slim
+++ b/source/partials/_card.html.slim
@@ -10,9 +10,13 @@
     show_item_type ||= nil
     special_subtitle ||= nil
     unequal_height ||= nil
+    show ||= nil
+    status ||= nil
+    last_date ||= nil
     image = ""
     image_link = ""
     title_style = ""
+    subtitle ||= nil
     subtitle_style = ""
     shadow = hide_shadow ? "" : "shadow-lg"
     height = unequal_height ? "" : "h-100"
@@ -28,6 +32,23 @@
       image = "card-img no-after"
       image_link = article.image_thumbnail
     end
+
+    if article.respond_to?(:announcement_date_closing) &&
+      article.announcement_date_closing.present?
+        show = article.show_date_after_closed
+        status = article.announcement_status.name
+        last_date = partial "partials/formatted-date",
+          locals: {date: article.announcement_date_closing}
+    end
+
+    subtitle =
+      if article.respond_to?(:subtitle) && article.subtitle.present?
+        article.subtitle
+      elsif status && status == "APERTO"
+        "Scade il #{last_date}"
+      elsif show && status == "CHIUSO"
+        "Chiuso il #{last_date}"
+      end
 
     if large_title
       title_style = "h2"
@@ -112,9 +133,9 @@
         - if special_subtitle && source
           p.h6.pt-3
             = article.source
-        - elsif article.respond_to?(:subtitle) && article.subtitle.present?
+        - elsif subtitle
           p.pt-2 class="#{subtitle_style}"
-            = article.subtitle
+            = subtitle
       .mt-auto.d-flex.flex-wrap-reverse.flex-row-reverse.align-items-end
         - tags = article.tags.present?
         - if !hide_tags && tags

--- a/source/partials/_cards-horizontal-list.html.slim
+++ b/source/partials/_cards-horizontal-list.html.slim
@@ -11,7 +11,7 @@ ruby:
   hide_shadow ||= nil
 
 - if items.present?
-  - cols = items.size
+  - cols = items.size > 1 ? items.size : 2
 
   - if title.present?
     .pt-5.pb-4.pb-lg-0

--- a/source/templates/homepage.html.slim
+++ b/source/templates/homepage.html.slim
@@ -63,6 +63,7 @@ h1.d-lg-none.h5.px-3.px-sm-5.text-md-center.pb-3.primary-bg.text-white.it-brand-
       = partial "partials/flag",
         locals: {flags: page.sections, image_right: true}
 
+/ blocco avvisi pubblici
 - if page.announcements.any?
   .container
     = partial "partials/cards-horizontal-list",
@@ -70,4 +71,5 @@ h1.d-lg-none.h5.px-3.px-sm-5.text-md-center.pb-3.primary-bg.text-white.it-brand-
       items: page.announcements,
       btn_url: dato.announcements_index}
 
+/ blocco numeri
 = partial "partials/numbers", locals: {numbers: page.numbers}


### PR DESCRIPTION
- Style layout in order to show a single element where we usually have 3-element blocks in homepage.
- If the element shown in the right-hand card of featured news ("in copertina"), show the closing date where other element's subtitle content would usually be shown.