### PR TITLE
chore: remove daily automated build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,6 @@ on:
     inputs:
       details:
         description: 'External dispatch'
-  schedule:
-    - cron: '0 6 * * *' # every day at 6.00 AM
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -21,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-      
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -47,7 +45,7 @@ jobs:
       run: |
         rm "./build/images/logo-mid-white-6d6c98f9.svg"
         cp "./source/images/logo-mitd-white.svg" "./build/images/logo-mid-white-6d6c98f9.svg"
-      
+
     - name: gh_pages_deploy
       run: |
         git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
@@ -58,7 +56,7 @@ jobs:
     - name: The job has failed
       if: cancelled() || failure()
       run: ./sh/notify.sh ${{ secrets.DATOCMS_ENDPOINT_ID }} error
-      
+
     - name: The job has succeeded
       if: success()
       run: ./sh/notify.sh ${{ secrets.DATOCMS_ENDPOINT_ID }} success


### PR DESCRIPTION
The daily build is kinda dangerous and it serves no purpose, since
there's nothing the build needs to keep up to date.