### PR TITLE
feat: re-add Vercel middleware to password protect staging

### DIFF
--- a/_middleware.ts
+++ b/_middleware.ts
@@ -1,0 +1,38 @@
+// Vercel middleware to password protect the staging deployment
+export default function middleware(req: Request) {
+  const basicAuthPasswords = process.env.BASIC_AUTH_PASSWORDS;
+  if (basicAuthPasswords === undefined) {
+    return new Response(null, {
+      headers: {
+        'x-middleware-next': '1',
+      },
+    });
+  }
+
+  const basicAuth = req.headers['authorization'];
+  if (basicAuth) {
+    const pwdLines = basicAuthPasswords.split(/\s+/);
+
+    const auth = basicAuth.split(' ')[1];
+    const [user, pwd] = atob(auth).split(':');
+
+    for (const line of pwdLines) {
+      const [u, p] = line.split(':');
+
+      if (user === u && pwd === p) {
+        return new Response(null, {
+          headers: {
+            'x-middleware-next': '1',
+          },
+        });
+      }
+    }
+  }
+
+  return new Response('Auth required', {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': 'Basic realm="Secure Area"',
+    },
+  });
+}


### PR DESCRIPTION
Vercel Middleware stabilized
(https://github.com/vercel/examples/issues/50#issuecomment-1175736527),
re-add the password protection for staging environments.

See 7728506eab0efb.

This reverts commit 8f01e6ed1a4e64ccadd4cba7c07a029a422cb0fb.